### PR TITLE
Hot springs generator

### DIFF
--- a/ElectricalProgressive-Basics/Content/Block/ESolarGenerator/BlockEntityESolarGenerator.cs
+++ b/ElectricalProgressive-Basics/Content/Block/ESolarGenerator/BlockEntityESolarGenerator.cs
@@ -1,21 +1,15 @@
 ﻿using ElectricalProgressive.Utils;
 using System;
-using System.Collections.Generic;
-using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
-using Vintagestory.API.Server;
 using Vintagestory.API.Util;
-using Vintagestory.GameContent;
 
 namespace ElectricalProgressive.Content.Block.ESolarGenerator;
 
 public class BlockEntityESolarGenerator : BlockEntityEFacingBase
 {
     private Facing _facing = Facing.None;
-
-    public BEBehaviorElectricalProgressive? ElectricalProgressive => GetBehavior<BEBehaviorElectricalProgressive>();
 
     /// <summary>
     /// Maximum power output for solar panel

--- a/ElectricalProgressive-QOL/Content/Block/EHotSpringsGenerator/BEBehaviorHotSpringsEGenerator.cs
+++ b/ElectricalProgressive-QOL/Content/Block/EHotSpringsGenerator/BEBehaviorHotSpringsEGenerator.cs
@@ -83,7 +83,6 @@ public class BEBehaviorHotSpringsEGenerator : BlockEntityBehavior, IElectricProd
         {
             return 0f;
         }
-        // Only give
         _powerGive = temp.Power * temp.Kpd;
         return _powerGive;
     }
@@ -118,10 +117,7 @@ public class BEBehaviorHotSpringsEGenerator : BlockEntityBehavior, IElectricProd
                                  ((int)entity.Power).ToString() + " " + Lang.Get("W"));
         stringBuilder.AppendLine("└ " + Lang.Get("kpd") + ": " + (entity.Kpd * 100).ToString("F1") + " %");
 
-        if (!string.IsNullOrEmpty(entity.ErrorMessage))
-        {
-            stringBuilder.AppendLine(Lang.Get(entity.ErrorMessage));
-        }
+        if (!string.IsNullOrEmpty(entity.ErrorMessage)) stringBuilder.AppendLine(Lang.Get(entity.ErrorMessage));
     }
 
 

--- a/ElectricalProgressive-QOL/Content/Block/EHotSpringsGenerator/BEBehaviorHotSpringsEGenerator.cs
+++ b/ElectricalProgressive-QOL/Content/Block/EHotSpringsGenerator/BEBehaviorHotSpringsEGenerator.cs
@@ -1,4 +1,4 @@
-﻿using ElectricalProgressive.Interface;
+using ElectricalProgressive.Interface;
 using ElectricalProgressive.Utils;
 using System;
 using System.Text;
@@ -7,14 +7,14 @@ using Vintagestory.API.Config;
 using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
 
-namespace ElectricalProgressive.Content.Block.ESolarGenerator;
+namespace ElectricalProgressive.Content.Block.EHotSpringsGenerator;
 
-public class BEBehaviorSolarEGenerator : BlockEntityBehavior, IElectricProducer
+public class BEBehaviorHotSpringsEGenerator : BlockEntityBehavior, IElectricProducer
 {
-    private float _powerOrder; // Просят столько энергии (сохраняется)
+    private float _powerOrder; // Power requested (saved)
     public const string PowerOrderKey = "electricalprogressive:powerOrder";
 
-    private float _powerGive; // Отдаем столько энергии (сохраняется)
+    private float _powerGive; // Power given (saved)
     public const string PowerGiveKey = "electricalprogressive:powerGive";
 
     private bool hasBurnout;
@@ -23,15 +23,15 @@ public class BEBehaviorSolarEGenerator : BlockEntityBehavior, IElectricProducer
     public new BlockPos Pos => Blockentity.Pos;
 
 
-    public BEBehaviorSolarEGenerator(BlockEntity blockEntity) : base(blockEntity)
+    public BEBehaviorHotSpringsEGenerator(BlockEntity blockEntity) : base(blockEntity)
     {
-        
+
     }
 
 
     public void Update()
     {
-        if (Blockentity is not BlockEntityESolarGenerator entity ||
+        if (Blockentity is not BlockEntityEHotSpringsGenerator entity ||
             entity.ElectricalProgressive == null ||
             entity.ElectricalProgressive.AllEparams is null)
         {
@@ -79,7 +79,7 @@ public class BEBehaviorSolarEGenerator : BlockEntityBehavior, IElectricProducer
 
     public float Produce_give()
     {
-        if (Blockentity is not BlockEntityESolarGenerator temp)
+        if (Blockentity is not BlockEntityEHotSpringsGenerator temp)
         {
             return 0f;
         }
@@ -94,6 +94,7 @@ public class BEBehaviorSolarEGenerator : BlockEntityBehavior, IElectricProducer
         _powerOrder = amount;
     }
 
+
     public float getPowerGive() => _powerGive;
 
 
@@ -101,13 +102,13 @@ public class BEBehaviorSolarEGenerator : BlockEntityBehavior, IElectricProducer
 
 
     /// <summary>
-    /// Подсказка при наведении на блок
+    /// Tooltip when hovering over the block
     /// </summary>
     public override void GetBlockInfo(IPlayer forPlayer, StringBuilder stringBuilder)
     {
         base.GetBlockInfo(forPlayer, stringBuilder);
 
-        if (Blockentity is not BlockEntityESolarGenerator entity)
+        if (Blockentity is not BlockEntityEHotSpringsGenerator entity)
             return;
 
 
@@ -116,11 +117,16 @@ public class BEBehaviorSolarEGenerator : BlockEntityBehavior, IElectricProducer
                                  ((int)Math.Min(_powerGive, _powerOrder)).ToString() + "/" +
                                  ((int)entity.Power).ToString() + " " + Lang.Get("W"));
         stringBuilder.AppendLine("└ " + Lang.Get("kpd") + ": " + (entity.Kpd * 100).ToString("F1") + " %");
+
+        if (!string.IsNullOrEmpty(entity.ErrorMessage))
+        {
+            stringBuilder.AppendLine(Lang.Get(entity.ErrorMessage));
+        }
     }
 
 
     /// <summary>
-    /// Сохранение параметров в дерево атрибутов
+    /// Save parameters to attribute tree
     /// </summary>
     /// <param name="tree"></param>
     public override void ToTreeAttributes(ITreeAttribute tree)
@@ -132,7 +138,7 @@ public class BEBehaviorSolarEGenerator : BlockEntityBehavior, IElectricProducer
 
 
     /// <summary>
-    /// Загрузка параметров из дерева атрибутов
+    /// Load parameters from attribute tree
     /// </summary>
     /// <param name="tree"></param>
     /// <param name="worldAccessForResolve"></param>

--- a/ElectricalProgressive-QOL/Content/Block/EHotSpringsGenerator/BlockEHotSpringsGenerator.cs
+++ b/ElectricalProgressive-QOL/Content/Block/EHotSpringsGenerator/BlockEHotSpringsGenerator.cs
@@ -1,0 +1,165 @@
+using ElectricalProgressive.Utils;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Vintagestory.API.Common;
+using Vintagestory.API.Config;
+using Vintagestory.API.MathTools;
+
+namespace ElectricalProgressive.Content.Block.EHotSpringsGenerator;
+
+public class BlockEHotSpringsGenerator : BlockEBase
+{
+    /// <summary>
+    /// Checks if the block can be placed
+    /// </summary>
+    /// <param name="world"></param>
+    /// <param name="byPlayer"></param>
+    /// <param name="itemstack"></param>
+    /// <param name="blockSel"></param>
+    /// <param name="failureCode"></param>
+    /// <returns></returns>
+    public override bool TryPlaceBlock(IWorldAccessor world, IPlayer byPlayer, ItemStack itemstack,
+       BlockSelection blockSel, ref string failureCode)
+    {
+        var selection = new Selection(blockSel);
+        var facing = Facing.None;
+
+        try
+        {
+            facing = FacingHelper.From(selection.Face, selection.Direction);
+        }
+        catch
+        {
+            return false;
+        }
+
+
+        if (
+            FacingHelper.Faces(facing).First() is { } blockFacing &&
+            !world.BlockAccessor
+                .GetBlock(blockSel.Position.AddCopy(blockFacing)).SideSolid[blockFacing.Opposite.Index]
+        )
+        {
+            return false;
+        }
+
+        return base.TryPlaceBlock(world, byPlayer, itemstack, blockSel, ref failureCode);
+    }
+
+
+
+
+    /// <summary>
+    /// Place the block
+    /// </summary>
+    /// <param name="world"></param>
+    /// <param name="byPlayer"></param>
+    /// <param name="blockSel"></param>
+    /// <param name="byItemStack"></param>
+    /// <returns></returns>
+    public override bool DoPlaceBlock(IWorldAccessor world, IPlayer byPlayer, BlockSelection blockSel,
+        ItemStack byItemStack)
+    {
+        var selection = new Selection(blockSel);
+
+        // Disallow stacking on the same block type
+        var belowPos = blockSel.Position.DownCopy();
+        var belowBlock = world.BlockAccessor.GetBlock(belowPos);
+
+        if (belowBlock == this)
+        {
+            return false;
+        }
+
+
+        var facing = Facing.None;
+
+        try
+        {
+            facing = FacingHelper.From(selection.Face, selection.Direction);
+        }
+        catch
+        {
+            return false;
+        }
+
+        if (
+            base.DoPlaceBlock(world, byPlayer, blockSel, byItemStack) &&
+            world.BlockAccessor.GetBlockEntity(blockSel.Position) is BlockEntityEHotSpringsGenerator entity
+        )
+        {
+            entity.Facing = facing;
+            LoadEProperties.Load(this, entity);
+
+            return true;
+        }
+
+        return false;
+    }
+
+
+
+
+    /// <summary>
+    /// Handler for neighbor block changes
+    /// </summary>
+    /// <param name="world"></param>
+    /// <param name="pos"></param>
+    /// <param name="neibpos"></param>
+    public override void OnNeighbourBlockChange(IWorldAccessor world, BlockPos pos, BlockPos neibpos)
+    {
+        base.OnNeighbourBlockChange(world, pos, neibpos);
+
+        if (world.BlockAccessor.GetBlockEntity(pos) is BlockEntityEHotSpringsGenerator)
+        {
+
+            if (!world.BlockAccessor.GetBlock(pos.AddCopy(BlockFacing.DOWN)).SideSolid[4]) // if the block below is no longer solid
+            {
+                world.BlockAccessor.BreakBlock(pos, null);
+            }
+        }
+    }
+
+
+
+    public override ItemStack[] GetDrops(IWorldAccessor world, BlockPos pos, IPlayer byPlayer,
+        float dropQuantityMultiplier = 1)
+    {
+        return [OnPickBlock(world, pos)];
+    }
+
+
+    public override ItemStack OnPickBlock(IWorldAccessor world, BlockPos pos)
+    {
+        var newState = Variant["state"] switch
+        {
+            "on" => "off",
+            "off" => "off"
+        };
+
+        var blockCode = CodeWithVariants(new Dictionary<string, string>
+        {
+            { "state", newState },
+            { "side", "south" }
+        });
+
+        var block = world.BlockAccessor.GetBlock(blockCode);
+        return new ItemStack(block);
+    }
+
+
+    /// <summary>
+    /// Get held item info for inventory
+    /// </summary>
+    /// <param name="inSlot"></param>
+    /// <param name="dsc"></param>
+    /// <param name="world"></param>
+    /// <param name="withDebugInfo"></param>
+    public override void GetHeldItemInfo(ItemSlot inSlot, StringBuilder dsc, IWorldAccessor world, bool withDebugInfo)
+    {
+        base.GetHeldItemInfo(inSlot, dsc, world, withDebugInfo);
+        dsc.AppendLine(Lang.Get("Voltage") + ": " + MyMiniLib.GetAttributeInt(inSlot.Itemstack.Block, "voltage", 0) + " " + Lang.Get("V"));
+        dsc.AppendLine(Lang.Get("WResistance") + ": " + ((MyMiniLib.GetAttributeBool(inSlot.Itemstack.Block, "isolatedEnvironment", false)) ? Lang.Get("Yes") : Lang.Get("No")));
+    }
+}

--- a/ElectricalProgressive-QOL/Content/Block/EHotSpringsGenerator/BlockEHotSpringsGenerator.cs
+++ b/ElectricalProgressive-QOL/Content/Block/EHotSpringsGenerator/BlockEHotSpringsGenerator.cs
@@ -13,7 +13,7 @@ public class BlockEHotSpringsGenerator : BlockEBase
     /// <summary>
     /// Checks if the block can be placed
     /// </summary>
-    /// <param name="world"></param>
+    /// <param name="world"></paramf>
     /// <param name="byPlayer"></param>
     /// <param name="itemstack"></param>
     /// <param name="blockSel"></param>
@@ -38,8 +38,7 @@ public class BlockEHotSpringsGenerator : BlockEBase
         if (
             FacingHelper.Faces(facing).First() is { } blockFacing &&
             !world.BlockAccessor
-                .GetBlock(blockSel.Position.AddCopy(blockFacing)).SideSolid[blockFacing.Opposite.Index]
-        )
+                .GetBlock(blockSel.Position.AddCopy(blockFacing)).SideSolid[blockFacing.Opposite.Index])
         {
             return false;
         }

--- a/ElectricalProgressive-QOL/Content/Block/EHotSpringsGenerator/BlockEntityEHotSpringsGenerator.cs
+++ b/ElectricalProgressive-QOL/Content/Block/EHotSpringsGenerator/BlockEntityEHotSpringsGenerator.cs
@@ -1,0 +1,254 @@
+using ElectricalProgressive.Utils;
+using System;
+using System.Collections.Generic;
+using Vintagestory.API.Client;
+using Vintagestory.API.Common;
+using Vintagestory.API.Datastructures;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
+using Vintagestory.API.Util;
+using Vintagestory.GameContent;
+
+namespace ElectricalProgressive.Content.Block.EHotSpringsGenerator;
+
+public class BlockEntityEHotSpringsGenerator : BlockEntityEFacingBase
+{
+    private Facing _facing = Facing.None;
+
+    public BEBehaviorElectricalProgressive? ElectricalProgressive => GetBehavior<BEBehaviorElectricalProgressive>();
+
+    /// <summary>
+    /// Maximum power output for hot springs generator
+    /// </summary>
+    public float Power
+    {
+        get
+        {
+            return _maxConsumption;
+        }
+    }
+
+    /// <summary>
+    /// Generator efficiency as a fraction
+    /// </summary>
+    public float Kpd;
+
+    /// <summary>
+    /// Error message to display in tooltip, empty if no error
+    /// </summary>
+    public string ErrorMessage = "";
+
+    private long _listenerId;
+    private int _maxConsumption;
+
+    /// <summary>
+    /// Block initialization
+    /// </summary>
+    /// <param name="api"></param>
+    public override void Initialize(ICoreAPI api)
+    {
+        base.Initialize(api);
+
+        if (api.Side == EnumAppSide.Server)
+        {
+            _listenerId = this.RegisterGameTickListener(OnHotSpringsTick, 1000);
+        }
+
+        _maxConsumption = MyMiniLib.GetAttributeInt(this.Block, "maxConsumption");
+    }
+
+
+    public override void OnReceivedClientPacket(IPlayer player, int packetid, byte[] data)
+    {
+        base.OnReceivedClientPacket(player, packetid, data);
+
+        ElectricalProgressive?.OnReceivedClientPacket(player, packetid, data);
+    }
+
+    public override void OnReceivedServerPacket(int packetid, byte[] data)
+    {
+        base.OnReceivedServerPacket(packetid, data);
+
+        ElectricalProgressive?.OnReceivedServerPacket(packetid, data);
+    }
+
+
+    /// <summary>
+    /// When the block is broken
+    /// </summary>
+    /// <param name="byPlayer"></param>
+    public override void OnBlockBroken(IPlayer byPlayer = null!)
+    {
+        base.OnBlockBroken(null);
+    }
+
+
+    /// <summary>
+    /// Called when the block is unloaded
+    /// </summary>
+    public override void OnBlockUnloaded()
+    {
+        base.OnBlockUnloaded();
+
+        this.ElectricalProgressive
+            ?.OnBlockUnloaded(); // call OnBlockUnloaded on BEBehaviorElectricalProgressive
+
+        // unregister the tick listener
+        UnregisterGameTickListener(_listenerId);
+    }
+
+    /// <summary>
+    /// Tick handler for hot springs generation
+    /// </summary>
+    /// <param name="deltatime"></param>
+    private void OnHotSpringsTick(float deltatime)
+    {
+        var beh = GetBehavior<BEBehaviorHotSpringsEGenerator>();
+        if (beh is null)
+            return;
+
+        Calculate_kpd();
+
+        bool effectivePowered = (int)Math.Min(beh.getPowerGive(), beh.getPowerOrder()) >= _maxConsumption * .05;
+        if (effectivePowered && this.Block.Variant["state"] == "off")
+        {
+            var originalBlock = Api.World.BlockAccessor.GetBlock(Pos);
+            var newBlockAL = originalBlock.CodeWithVariant("state", "on");
+            var newBlock = Api.World.GetBlock(newBlockAL);
+            Api.World.BlockAccessor.ExchangeBlock(newBlock.Id, Pos);
+            MarkDirty();
+        }
+        if (!effectivePowered && this.Block.Variant["state"] == "on")
+        {
+            var originalBlock = Api.World.BlockAccessor.GetBlock(Pos);
+            var newBlockAL = originalBlock.CodeWithVariant("state", "off");
+            var newBlock = Api.World.GetBlock(newBlockAL);
+            Api.World.BlockAccessor.ExchangeBlock(newBlock.Id, Pos);
+            MarkDirty();
+        }
+    }
+
+
+    /// <summary>
+    /// Calculates the efficiency based on boiling water surrounding the generator.
+    /// Requires boiling water on all four horizontal sides to function.
+    /// Efficiency is reduced when multiple generators are within 8 blocks.
+    /// </summary>
+    private void Calculate_kpd()
+    {
+        var accessor = Api.World.BlockAccessor;
+
+        bool IsBoilingWater(BlockPos pos) =>
+            accessor.GetBlock(pos, BlockLayersAccess.Fluid).Code?.Path.StartsWith("boilingwater") == true;
+
+        bool surrounded = IsBoilingWater(Pos.NorthCopy())
+            && IsBoilingWater(Pos.SouthCopy())
+            && IsBoilingWater(Pos.EastCopy())
+            && IsBoilingWater(Pos.WestCopy());
+
+        if (!surrounded)
+        {
+            Kpd = 0;
+            ErrorMessage = "electricalprogressiveqol:hotsprings-not-surrounded";
+            return;
+        }
+
+        // Count nearby generators within 8 blocks
+        int nearbyGenerators = CountNearbyGenerators(8);
+
+        Kpd = nearbyGenerators switch
+        {
+            0 => 1f,
+            1 => 0.5f,
+            2 => 0.25f,
+            3 => 0.1f,
+            _ => 0.05f
+        };
+
+        ErrorMessage = nearbyGenerators > 0 ? "electricalprogressiveqol:hotsprings-nearby-penalty" : "";
+    }
+
+    /// <summary>
+    /// Counts other hot springs generators within the specified range that are actively producing power.
+    /// </summary>
+    private int CountNearbyGenerators(int range)
+    {
+        var accessor = Api.World.BlockAccessor;
+        int count = 0;
+
+        for (int x = -range; x <= range; x++)
+        {
+            for (int y = -range; y <= range; y++)
+            {
+                for (int z = -range; z <= range; z++)
+                {
+                    if (x == 0 && y == 0 && z == 0) continue; // Skip self
+
+                    var checkPos = Pos.AddCopy(x, y, z);
+                    var blockEntity = accessor.GetBlockEntity(checkPos);
+
+                    if (blockEntity is BlockEntityEHotSpringsGenerator generator && generator.Kpd > 0)
+                        count++;
+                }
+            }
+        }
+
+        return count;
+    }
+
+
+    /// <summary>
+    /// When the block is removed, close the dialog and disconnect electricity
+    /// </summary>
+    public override void OnBlockRemoved()
+    {
+        base.OnBlockRemoved();
+
+        var electricity = ElectricalProgressive;
+
+        if (electricity != null)
+        {
+            electricity.Connection = Facing.None;
+        }
+
+        // unregister the tick listener
+        UnregisterGameTickListener(_listenerId);
+
+    }
+
+
+    /// <summary>
+    /// Save attributes
+    /// </summary>
+    /// <param name="tree"></param>
+    public override void ToTreeAttributes(ITreeAttribute tree)
+    {
+        base.ToTreeAttributes(tree);
+        tree.SetBytes("electricalprogressive:facing", SerializerUtil.Serialize(this._facing));
+        tree.SetFloat("electricalprogressive:kpd", Kpd);
+        tree.SetString("electricalprogressive:errorMessage", ErrorMessage);
+    }
+
+
+    /// <summary>
+    /// Load attributes
+    /// </summary>
+    /// <param name="tree"></param>
+    /// <param name="worldForResolving"></param>
+    public override void FromTreeAttributes(ITreeAttribute tree, IWorldAccessor worldForResolving)
+    {
+        base.FromTreeAttributes(tree, worldForResolving);
+
+        try
+        {
+            this._facing = SerializerUtil.Deserialize<Facing>(tree.GetBytes("electricalprogressive:facing"));
+        }
+        catch (Exception exception)
+        {
+            this.Api?.Logger.Error(exception.ToString());
+        }
+
+        Kpd = tree.GetFloat("electricalprogressive:kpd");
+        ErrorMessage = tree.GetString("electricalprogressive:errorMessage", "");
+    }
+}

--- a/ElectricalProgressive-QOL/Content/Block/EHotSpringsGenerator/EHeatExchanger/BlockEHeatExchanger.cs
+++ b/ElectricalProgressive-QOL/Content/Block/EHotSpringsGenerator/EHeatExchanger/BlockEHeatExchanger.cs
@@ -1,0 +1,82 @@
+using System.Text;
+using Vintagestory.API.Common;
+using Vintagestory.API.Config;
+using Vintagestory.API.MathTools;
+using ElectricalProgressive.Content.Block.EHotSpringsGenerator;
+
+namespace ElectricalProgressive.Content.Block.EHeatExchanger;
+
+public class BlockEHeatExchanger : Vintagestory.API.Common.Block
+{
+    /// <summary>
+    /// Checks if the block can be placed - must be adjacent to a hot springs generator
+    /// </summary>
+    public override bool TryPlaceBlock(IWorldAccessor world, IPlayer byPlayer, ItemStack itemstack,
+       BlockSelection blockSel, ref string failureCode)
+    {
+        // Check if any adjacent block (including diagonals) is a hot springs generator
+        if (!IsAdjacentToHotSpringsGenerator(world, blockSel.Position))
+        {
+            return false;
+        }
+
+        return base.TryPlaceBlock(world, byPlayer, itemstack, blockSel, ref failureCode);
+    }
+
+    
+
+    /// <summary>
+    /// Checks if the position is horizontally adjacent to a hot springs generator (including diagonals)
+    /// </summary>
+    private bool IsAdjacentToHotSpringsGenerator(IWorldAccessor world, BlockPos pos)
+    {
+        var accessor = world.BlockAccessor;
+
+        // Check all 8 horizontal directions (N, S, E, W, NE, NW, SE, SW)
+        BlockPos[] adjacentPositions = new[]
+        {
+            pos.NorthCopy(),
+            pos.SouthCopy(),
+            pos.EastCopy(),
+            pos.WestCopy(),
+            pos.NorthCopy().EastCopy(),  // NE
+            pos.NorthCopy().WestCopy(),  // NW
+            pos.SouthCopy().EastCopy(),  // SE
+            pos.SouthCopy().WestCopy()   // SW
+        };
+
+        foreach (var adjPos in adjacentPositions)
+        {
+            var blockEntity = accessor.GetBlockEntity(adjPos);
+            if (blockEntity is BlockEntityEHotSpringsGenerator)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// When a neighbor block changes, check if we should break
+    /// </summary>
+    public override void OnNeighbourBlockChange(IWorldAccessor world, BlockPos pos, BlockPos neibpos)
+    {
+        base.OnNeighbourBlockChange(world, pos, neibpos);
+
+        // If no longer adjacent to a hot springs generator, break
+        if (!IsAdjacentToHotSpringsGenerator(world, pos))
+        {
+            world.BlockAccessor.BreakBlock(pos, null);
+        }
+    }
+
+    /// <summary>
+    /// Get held item info for inventory
+    /// </summary>
+    public override void GetHeldItemInfo(ItemSlot inSlot, StringBuilder dsc, IWorldAccessor world, bool withDebugInfo)
+    {
+        base.GetHeldItemInfo(inSlot, dsc, world, withDebugInfo);
+        dsc.AppendLine(Lang.Get("electricalprogressiveqol:heatexchanger-placement-hint"));
+    }
+}

--- a/ElectricalProgressive-QOL/ElectricalProgressiveQOL.cs
+++ b/ElectricalProgressive-QOL/ElectricalProgressiveQOL.cs
@@ -10,6 +10,7 @@ using ElectricalProgressive.Content.Block.EOven;
 using ElectricalProgressive.Content.Block.ESFonar;
 using ElectricalProgressive.Content.Block.EStove;
 using ElectricalProgressive.Content.Block.EHotSpringsGenerator;
+using ElectricalProgressive.Content.Block.EHeatExchanger;
 using ElectricalProgressive.Patch;
 using HarmonyLib;
 using Newtonsoft.Json.Linq;
@@ -126,6 +127,8 @@ public class ElectricalProgressiveQOL : ModSystem
         api.RegisterBlockClass("BlockEHotSpringsGenerator", typeof(BlockEHotSpringsGenerator));
         api.RegisterBlockEntityClass("BlockEntityEHotSpringsGenerator", typeof(BlockEntityEHotSpringsGenerator));
         api.RegisterBlockEntityBehaviorClass("BEBehaviorHotSpringsEGenerator", typeof(BEBehaviorHotSpringsEGenerator));
+
+        api.RegisterBlockClass("BlockEHeatExchanger", typeof(BlockEHeatExchanger));
 
         // xskills интеграция через рефлексию
         if (api.ModLoader.IsModEnabled("xskillsrabite") || api.ModLoader.IsModEnabled("xskills"))

--- a/ElectricalProgressive-QOL/ElectricalProgressiveQOL.cs
+++ b/ElectricalProgressive-QOL/ElectricalProgressiveQOL.cs
@@ -9,6 +9,7 @@ using ElectricalProgressive.Content.Block.ELamp;
 using ElectricalProgressive.Content.Block.EOven;
 using ElectricalProgressive.Content.Block.ESFonar;
 using ElectricalProgressive.Content.Block.EStove;
+using ElectricalProgressive.Content.Block.EHotSpringsGenerator;
 using ElectricalProgressive.Patch;
 using HarmonyLib;
 using Newtonsoft.Json.Linq;
@@ -121,6 +122,10 @@ public class ElectricalProgressiveQOL : ModSystem
         api.RegisterBlockClass("BlockEFence", typeof(BlockEFence));
         api.RegisterBlockEntityClass("BlockEntityEFence", typeof(BlockEntityEFence));
         api.RegisterBlockEntityBehaviorClass("BEBehaviorEFence", typeof(BEBehaviorEFence));
+
+        api.RegisterBlockClass("BlockEHotSpringsGenerator", typeof(BlockEHotSpringsGenerator));
+        api.RegisterBlockEntityClass("BlockEntityEHotSpringsGenerator", typeof(BlockEntityEHotSpringsGenerator));
+        api.RegisterBlockEntityBehaviorClass("BEBehaviorHotSpringsEGenerator", typeof(BEBehaviorHotSpringsEGenerator));
 
         // xskills интеграция через рефлексию
         if (api.ModLoader.IsModEnabled("xskillsrabite") || api.ModLoader.IsModEnabled("xskills"))

--- a/ElectricalProgressive-QOL/assets/electricalprogressiveqol/blocktypes/eheatexchanger.json
+++ b/ElectricalProgressive-QOL/assets/electricalprogressiveqol/blocktypes/eheatexchanger.json
@@ -1,0 +1,62 @@
+{
+  "code": "eheatexchanger",
+  "class": "BlockEHeatExchanger",
+
+  "attributes": {
+    "handbook": {
+      "groupBy": [ "eheatexchanger-*" ],
+      "extraSections": [
+        {
+          "title": "electricalprogressiveqol:block-handbooktitle-eheatexchanger",
+          "text": "electricalprogressiveqol:block-handbooktext-eheatexchanger"
+        }
+      ]
+    }
+  },
+
+  "creativeinventory": {
+    "general": [ "*" ],
+    "electricity": [ "*" ]
+  },
+
+  "shape": {
+    "base": "electricalprogressivebasics:block/termoplastini/termoplastini",
+    "scale": 0.8
+  },
+
+  "blockmaterial": "Metal",
+  "sidesolid": {
+    "all": false
+  },
+  "sideopaque": {
+    "all": false
+  },
+  "collisionbox": {
+    "x1": 0,
+    "y1": 0,
+    "z1": 0,
+    "x2": 1,
+    "y2": 0.8,
+    "z2": 1
+  },
+  "selectionbox": {
+    "x1": 0,
+    "y1": 0,
+    "z1": 0,
+    "x2": 1,
+    "y2": 0.8,
+    "z2": 1
+  },
+  "resistance": 3.5,
+  "lightAbsorption": 0,
+
+  "sounds": {
+    "walk": "game:walk/stone",
+    "place": "game:block/anvil",
+    "hit": "game:block/anvil",
+    "break": "game:block/anvil"
+  },
+
+  "heldTpIdleAnimation": "holdbothhandslarge",
+  "heldTpUseAnimation": "twohandplaceblock"
+}

--- a/ElectricalProgressive-QOL/assets/electricalprogressiveqol/blocktypes/ehotspringsgenerator.json
+++ b/ElectricalProgressive-QOL/assets/electricalprogressiveqol/blocktypes/ehotspringsgenerator.json
@@ -29,7 +29,7 @@
     "maxCurrent": 1024.0,
     "isolated": true,
     "isolatedEnvironment": true,
-    "maxConsumption": 250,
+    "maxConsumption": 200,
     "handbook": {
       "groupBy": [ "ehotspringsgenerator-*" ],
       "extraSections": [

--- a/ElectricalProgressive-QOL/assets/electricalprogressiveqol/blocktypes/ehotspringsgenerator.json
+++ b/ElectricalProgressive-QOL/assets/electricalprogressiveqol/blocktypes/ehotspringsgenerator.json
@@ -1,0 +1,117 @@
+{
+  "code": "ehotspringsgenerator",
+  "class": "BlockEHotSpringsGenerator",
+  "entityClass": "BlockEntityEHotSpringsGenerator",
+  "behaviors": [
+    {
+      "name": "HorizontalOrientable",
+      "properties": {
+        "dropBlockFace": "south"
+      }
+    }
+  ],
+
+
+
+  "entityBehaviors": [
+    {
+      "name": "BEBehaviorHotSpringsEGenerator"
+    },
+    {
+      "name": "ElectricalProgressive"
+    }
+  ],
+
+  "attributes": {
+    "blockEProperties": "main",
+    "facesEProperties": [ "down" ],
+    "voltage": 32,
+    "maxCurrent": 1024.0,
+    "isolated": true,
+    "isolatedEnvironment": true,
+    "maxConsumption": 250,
+    "handbook": {
+      "groupBy": [ "ehotspringsgenerator-*" ],
+      "extraSections": [
+        {
+          "title": "electricalprogressiveqol:block-handbooktitle-ehotspringsgenerator",
+          "text": "electricalprogressiveqol:block-handbooktext-ehotspringsgenerator"
+        }
+      ]
+    }
+  },
+
+  "creativeinventory": {
+    "general": [ "*-off-south" ],
+    "electricity": [ "*-off-south" ]
+  },
+
+  "variantgroups": [
+    {
+      "code": "state",
+      "states": [
+        "on",
+        "off"
+      ]
+    },
+    {
+      "code": "side",
+      "loadFromProperties": "abstract/horizontalorientation"
+    }
+  ],
+
+
+  "shapebytype": {
+    "*-north": {
+      "base": "electricalprogressivebasics:block/solargenerator/solargenerator-{state}",
+      "rotateY": 0
+    },
+    "*-east": {
+      "base": "electricalprogressivebasics:block/solargenerator/solargenerator-{state}",
+      "rotateY": 270
+    },
+    "*-south": {
+      "base": "electricalprogressivebasics:block/solargenerator/solargenerator-{state}",
+      "rotateY": 180
+    },
+    "*-west": {
+      "base": "electricalprogressivebasics:block/solargenerator/solargenerator-{state}",
+      "rotateY": 90
+    }
+  },
+
+
+
+  "blockmaterial": "Stone",
+  "sidesolid": {
+    "all": false
+  },
+  "sideopaque": {
+    "all": false
+  },
+  "collisionbox": {
+    "x1": 0,
+    "y1": 0,
+    "z1": 0,
+    "x2": 1,
+    "y2": 0.25,
+    "z2": 1
+  },
+  "selectionbox": {
+    "x1": 0,
+    "y1": 0,
+    "z1": 0,
+    "x2": 1,
+    "y2": 0.25,
+    "z2": 1
+  },
+  "resistance": 3.5,
+  "lightAbsorption": 0,
+
+  "sounds": {
+    "walk": "game:walk/stone"
+  },
+
+  "heldTpIdleAnimation": "holdbothhandslarge",
+  "heldTpUseAnimation": "twohandplaceblock"
+}

--- a/ElectricalProgressive-QOL/assets/electricalprogressiveqol/lang/en.json
+++ b/ElectricalProgressive-QOL/assets/electricalprogressiveqol/lang/en.json
@@ -133,9 +133,14 @@
   "block-ehotspringsgenerator-*": "Hot Springs Generator",
   "block-ehotspringsgenerator-burned-south": "Hot Springs Generator (Burned)",
   "block-handbooktitle-ehotspringsgenerator": "Usage",
-  "block-handbooktext-ehotspringsgenerator": "A generator that harnesses hot springs to produce electricity.",
-  "electricalprogressiveqol:hotsprings-nearby-penalty": "Multiple Hot Springs Generators nearby, efficiency reduced",
-  "electricalprogressiveqol:hotsprings-not-surrounded": "Must be surrounded by hot springs on all sides to function",
+  "block-handbooktext-ehotspringsgenerator": "A generator that harnesses hot springs to produce electricity. The generator must be surrounded by hot springs on all sides. Efficiency can be improved by placing <a href=\"handbook:\/\/block-electricalprogressiveqol:eheatexchanger\">heat exchangers</a> adjacent to the generator. Multiple Hot Springs Generators nearby will significantly reduce efficiency.",
+  "electricalprogressiveqol:hotsprings-nearby-penalty": "Multiple Generators nearby, efficiency reduced",
+  "electricalprogressiveqol:hotsprings-not-surrounded": "Must be surrounded by Hot Springs",
+
+  "block-eheatexchanger": "Heat Exchanger",
+  "block-handbooktitle-eheatexchanger": "Usage",
+  "block-handbooktext-eheatexchanger": "A heat exchanger that must be placed adjacent to a Hot Springs Generator (including diagonally). Each heat exchanger improves the generator's efficiency, scaling from 5% with none to 100% with 7 heat exchangers.",
+  "electricalprogressiveqol:heatexchanger-placement-hint": "Must be placed next to a Hot Spring Generator",
 
   "progress": "Progress: {0:P0}"
 

--- a/ElectricalProgressive-QOL/assets/electricalprogressiveqol/lang/en.json
+++ b/ElectricalProgressive-QOL/assets/electricalprogressiveqol/lang/en.json
@@ -130,6 +130,13 @@
   "block-handbooktitle-efence": "Usage",
   "block-handbooktext-efence": "A good defense against unwanted guests. Deals electric damage on contact. Doesn't consume energy, but must be connected to an electrical circuit to function.",
 
+  "block-ehotspringsgenerator-*": "Hot Springs Generator",
+  "block-ehotspringsgenerator-burned-south": "Hot Springs Generator (Burned)",
+  "block-handbooktitle-ehotspringsgenerator": "Usage",
+  "block-handbooktext-ehotspringsgenerator": "A generator that harnesses hot springs to produce electricity.",
+  "electricalprogressiveqol:hotsprings-nearby-penalty": "Multiple Hot Springs Generators nearby, efficiency reduced",
+  "electricalprogressiveqol:hotsprings-not-surrounded": "Must be surrounded by hot springs on all sides to function",
+
   "progress": "Progress: {0:P0}"
 
 }

--- a/ElectricalProgressive-QOL/assets/electricalprogressiveqol/recipes/grid/eheatexchanger.json
+++ b/ElectricalProgressive-QOL/assets/electricalprogressiveqol/recipes/grid/eheatexchanger.json
@@ -1,0 +1,35 @@
+[
+  {
+    "ingredientPattern": "SCH,GG_",
+    "width": 3,
+    "height": 2,
+    "ingredients": {
+      "C": {
+        "type": "item",
+        "code": "game:metalplate-copper",
+        "quantity": 4
+      },
+      "G": {
+        "type": "item",
+        "code": "game:metalbit-gold",
+        "quantity": 4
+      },
+      "S": {
+        "type": "item",
+        "code": "game:metalbit-silver",
+        "quantity": 2
+      },
+      "H": {
+        "type": "item",
+        "code": "game:hammer-*",
+        "isTool": true,
+        "toolDurabilityCost": 4
+      }
+    },
+    "output": {
+      "type": "block",
+      "code": "electricalprogressiveqol:eheatexchanger",
+      "quantity": 1
+    }
+  }
+]

--- a/ElectricalProgressive-QOL/assets/electricalprogressiveqol/recipes/grid/ehotspringsgenerator.json
+++ b/ElectricalProgressive-QOL/assets/electricalprogressiveqol/recipes/grid/ehotspringsgenerator.json
@@ -1,0 +1,33 @@
+[
+  {
+    "ingredientPattern": "GIH,GIE",
+    "width": 3,
+    "height": 2,
+    "ingredients": {
+      "E": {
+        "type": "block",
+        "code": "electricalprogressivebasics:egenerator-tier1-*",
+        "allowedVariants": ["stator", "normal"]
+      },
+      "G": {
+        "type": "item",
+        "code": "game:metalplate-gold"
+      },
+      "I": {
+        "type": "item",
+        "code": "game:metalplate-iron"
+      },
+      "H": {
+        "type": "item",
+        "code": "game:hammer-*",
+        "isTool": true,
+        "toolDurabilityCost": 4
+      }
+    },
+    "output": {
+      "type": "block",
+      "code": "electricalprogressiveqol:ehotspringsgenerator-off-south",
+      "quantity": 1
+    }
+  }
+]


### PR DESCRIPTION
Hot Springs Generator!

This generator must be placed in boiling water (hot springs) and be surrounded by all four sides with boiling water. It produces a maximum of 200 watts of power. However, without Heat Exchangers on 7 sides of the generator it is less efficient. Without any heat exchangers it just produces 10 watts. The more heat exchangers added, the more efficient it is. 

If there are nearby hot springs generators (that are in boiling water, not just nearby not doing anything) then there is a huge efficiency loss. This is because I did not want to allow the player to become overpowered. The logic is that multiple generators would pull too much heat out of the water. They need enough space!

I have placeholder models in place. The heat exchangers use the thermal generator's thermoelectric plates for now. The hot springs generator model is just the solar panel. 
